### PR TITLE
Polish UX and fix signup session/permissions

### DIFF
--- a/littleX_FULLSTACK/components/TweetCard.cl.jac
+++ b/littleX_FULLSTACK/components/TweetCard.cl.jac
@@ -75,7 +75,7 @@ def:pub TweetCard(props: Any) -> Any {
                 {(
                     <button
                         className="lx-act-btn lx-act-delete"
-                        onClick={lambda -> None { deleteFn.call(None, tweet["id"]); }}
+                        onClick={lambda -> None { if confirm("Delete this post? This cannot be undone.") { deleteFn.call(None, tweet["id"]); } }}
                     >
                         <Trash2 size={16} />
                     </button>
@@ -89,7 +89,6 @@ def:pub TweetCard(props: Any) -> Any {
                             <div>
                                 <div className="lx-comment-meta">
                                     <strong>{c["username"]}</strong>
-                                    <span>{" · "}</span>
                                 </div>
                                 <div className="lx-comment-text">{c["content"]}</div>
                             </div>

--- a/littleX_FULLSTACK/frontend.cl.jac
+++ b/littleX_FULLSTACK/frontend.cl.jac
@@ -2,7 +2,7 @@
 
 import from "@jac/runtime" { jacSignup, jacLogin, jacLogout, jacIsLoggedIn }
 sv import from .server { setup_profile, get_profile, get_all_profiles, follow_user, unfollow_user, create_tweet, delete_tweet, like_tweet, add_comment, load_feed, get_trending, create_channel, join_channel, leave_channel, get_channels, get_channel_detail, create_channel_tweet }
-import from "lucide-react" { Home, Compass, User, LogOut, Search, Feather, Hash, Users, Plus, ArrowLeft }
+import from "lucide-react" { Home, Compass, User, LogOut, Search, Feather, Hash, Users, Plus, ArrowLeft, X }
 import from .components.TweetCard { TweetCard }
 import from .components.AuthForm { AuthForm }
 import "./global.css";
@@ -92,6 +92,9 @@ def:pub app() -> Any {
     displayUsername = profileUsername.split("@")[0] if profileUsername.includes("@") else profileUsername;
     profileAvatar = "https://i.pravatar.cc/150?u=fake@" + profileUsername;
     followingIds = [f["id"] for f in myProfile.following] if myProfile and myProfile.following else [];
+    followingCount = len(myProfile.following) if myProfile and myProfile.following else 0;
+    followerCount = len(myProfile.followers) if myProfile and myProfile.followers else 0;
+    postCount = len(myProfile.tweets) if myProfile and myProfile.tweets else 0;
     charsLeft = 280 - composerText.length;
     ring_progress = Math.min(1.0, (280 - charsLeft) / 280.0);
     ring_offset = String(62.83 * (1.0 - ring_progress));
@@ -109,7 +112,7 @@ def:pub app() -> Any {
             <nav className="lx-nav">
                 <div
                     className={"lx-nav-item" + (" lx-nav-item-active" if activeTab == "feed" else "")}
-                    onClick={lambda -> None { activeTab = "feed"; }}
+                    onClick={lambda -> None { activeTab = "feed"; if searchQuery { searchQuery = ""; handleSearch(""); } }}
                 >
                     <Home size={22} />
                     <span>Home</span>
@@ -368,7 +371,7 @@ def:pub app() -> Any {
                                                 ) if ch["description"] else None}
                                                 <div className="lx-channel-item-meta">
                                                     <Users size={12} />
-                                                    <span>{String(ch["member_count"]) + " members"}</span>
+                                                    <span>{String(ch["member_count"]) + (" member" if ch["member_count"] == 1 else " members")}</span>
                                                 </div>
                                             </div>
                                             {(
@@ -400,7 +403,7 @@ def:pub app() -> Any {
                                 ) if selectedChannel.description else None}
                                 <div className="lx-channel-meta">
                                     <Users size={14} />
-                                    <span>{String(selectedChannel.member_count) + " members"}</span>
+                                    <span>{String(selectedChannel.member_count) + (" member" if selectedChannel.member_count == 1 else " members")}</span>
                                     {(
                                         <button
                                             className="lx-edit-profile-btn"
@@ -505,16 +508,16 @@ def:pub app() -> Any {
                         ) if editingBio else None}
                         <div className="lx-profile-stats">
                             <div className="lx-profile-stat">
-                                <strong>{String(len(myProfile.following) if myProfile and myProfile.following else 0)}</strong>
+                                <strong>{String(followingCount)}</strong>
                                 Following
                             </div>
                             <div className="lx-profile-stat">
-                                <strong>{String(len(myProfile.followers) if myProfile and myProfile.followers else 0)}</strong>
-                                Followers
+                                <strong>{String(followerCount)}</strong>
+                                {("Follower" if followerCount == 1 else "Followers")}
                             </div>
                             <div className="lx-profile-stat">
-                                <strong>{String(len(myProfile.tweets) if myProfile and myProfile.tweets else 0)}</strong>
-                                Posts
+                                <strong>{String(postCount)}</strong>
+                                {("Post" if postCount == 1 else "Posts")}
                             </div>
                         </div>
                     </div>
@@ -547,6 +550,15 @@ def:pub app() -> Any {
                         onChange={lambda e: Any -> None { searchQuery = e.target.value; }}
                         onKeyDown={lambda e: Any -> None { if e.key == "Enter" { handleSearch(e.target.value); } }}
                     />
+                    {(
+                        <button
+                            className="lx-search-clear"
+                            title="Clear search"
+                            onClick={lambda -> None { searchQuery = ""; handleSearch(""); }}
+                        >
+                            <X size={16} />
+                        </button>
+                    ) if searchQuery else None}
                     <button
                         className="lx-search-btn"
                         onClick={lambda -> None { handleSearch(searchQuery); }}
@@ -565,7 +577,7 @@ def:pub app() -> Any {
                                 onClick={lambda -> None { searchQuery = t["tag"]; handleSearch(t["tag"]); activeTab = "feed"; }}
                             >
                                 <span className="lx-trend-tag">{t["tag"]}</span>
-                                <span className="lx-trend-count">{String(t["count"]) + " posts"}</span>
+                                <span className="lx-trend-count">{String(t["count"]) + (" post" if t["count"] == 1 else " posts")}</span>
                             </div>
                             for t in trendingTags
                         ]}
@@ -614,7 +626,7 @@ def:pub app() -> Any {
         <nav className="lx-mobile-nav">
             <div
                 className={"lx-mobile-nav-item" + (" lx-mobile-nav-item-active" if activeTab == "feed" else "")}
-                onClick={lambda -> None { activeTab = "feed"; }}
+                onClick={lambda -> None { activeTab = "feed"; if searchQuery { searchQuery = ""; handleSearch(""); } }}
             >
                 <Home size={24} />
             </div>

--- a/littleX_FULLSTACK/frontend.impl.jac
+++ b/littleX_FULLSTACK/frontend.impl.jac
@@ -54,13 +54,22 @@ impl app.handleSignup -> None {
     }
     authLoading = True;
     result = await jacSignup(authUsername, authPassword);
-    authLoading = False;
     if result["ok"] or result["success"] {
-        localStorage.setItem("lx_username", authUsername);
-        isLoggedIn = True;
-        authPassword = "";
-        authError = "";
+        # jacSignup only registers the account; establish a session by
+        # logging in so the first walker calls aren't rejected with 401.
+        loginResult = await jacLogin(authUsername, authPassword);
+        authLoading = False;
+        if loginResult and (loginResult["ok"] or loginResult == True) {
+            localStorage.setItem("lx_username", authUsername);
+            isLoggedIn = True;
+            authPassword = "";
+            authError = "";
+        } else {
+            isSignup = False;
+            authError = "Account created. Please log in.";
+        }
     } else {
+        authLoading = False;
         authError = (result["error"]["message"] if result["error"] and result["error"]["message"] else (result["error"] if result["error"] else "Signup failed"));
     }
 }
@@ -88,6 +97,8 @@ impl app.postTweet -> None {
     tweets = feedResult.reports[0] if feedResult.reports else [];
     profileResult = root spawn get_profile();
     myProfile = profileResult.reports[0] if profileResult.reports else myProfile;
+    trendResult = root spawn get_trending();
+    trendingTags = trendResult.reports[0] if trendResult.reports else [];
 }
 
 impl app.handleLike(tweetId: str) -> None {

--- a/littleX_FULLSTACK/global.css
+++ b/littleX_FULLSTACK/global.css
@@ -788,6 +788,28 @@ body::before {
   transform: translateY(-1px);
 }
 
+.lx-search-clear {
+  background: var(--lx-bg-raised);
+  color: var(--lx-text-muted);
+  border: 1px solid var(--lx-border);
+  border-radius: 10px;
+  width: 2.1rem;
+  height: 2.1rem;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition:
+    color 0.2s,
+    border-color 0.2s;
+}
+
+.lx-search-clear:hover {
+  color: var(--lx-text);
+  border-color: var(--lx-accent-border);
+}
+
 /* ── Widget ── */
 
 .lx-widget {

--- a/littleX_FULLSTACK/server.jac
+++ b/littleX_FULLSTACK/server.jac
@@ -201,7 +201,7 @@ walker create_tweet {
             likes=[],
             comments=[]
         );
-        grant(tweet[0], level=ConnectPerm);
+        grant(tweet[0], level=WritePerm);
         t = tweet[0];
         report {"id": jid(t), "content": t.content, "author_username": t.author_username, "created_at": t.created_at, "likes": t.likes, "comments": t.comments};
     }
@@ -603,7 +603,7 @@ walker create_channel_tweet {
                     likes=[],
                     comments=[]
                 );
-                grant(tweet[0], level=ConnectPerm);
+                grant(tweet[0], level=WritePerm);
                 t = tweet[0];
                 report {
                     "id": jid(t),


### PR DESCRIPTION
## Summary
- Add a clear-search button and reset search when returning Home
- Pluralize members/followers/posts/trending counts correctly (1 member vs 2 members)
- Confirm before deleting a post
- Auto-login after signup so the first walker calls aren't rejected with 401
- Refresh trending tags after posting a tweet
- Grant `WritePerm` instead of `ConnectPerm` on created tweets

## Files
- `components/TweetCard.cl.jac` — delete confirmation, comment meta cleanup
- `frontend.cl.jac` — clear-search button, pluralization, Home tab search reset
- `frontend.impl.jac` — signup auto-login, trending refresh after post
- `global.css` — `.lx-search-clear` button styles
- `server.jac` — `WritePerm` on created tweets