### PR TITLE
Introduce typed view models and tighten type annotations

### DIFF
--- a/littleX_FULLSTACK/components/AuthForm.cl.jac
+++ b/littleX_FULLSTACK/components/AuthForm.cl.jac
@@ -1,6 +1,6 @@
 """Authentication form component for Little X."""
 
-def:pub AuthForm(props: Any) -> Any {
+def:pub AuthForm(props: any) -> JsxElement {
     isSignup = props.isSignup;
     username = props.username;
     password = props.password;

--- a/littleX_FULLSTACK/components/Button.cl.jac
+++ b/littleX_FULLSTACK/components/Button.cl.jac
@@ -1,6 +1,6 @@
 """Button component for the Jac client application."""
 
-def:pub Button(label: str, onClick: any, variant: str = "primary", disabled: bool = False) -> any {
+def:pub Button(label: str, onClick: any, variant: str = "primary", disabled: bool = False) -> JsxElement {
     base_styles = {
         "padding": "0.75rem 1.5rem",
         "fontSize": "1rem",

--- a/littleX_FULLSTACK/components/TweetCard.cl.jac
+++ b/littleX_FULLSTACK/components/TweetCard.cl.jac
@@ -2,7 +2,7 @@
 
 import from "lucide-react" { Heart, MessageCircle, Trash2, Repeat2 }
 
-def:pub TweetCard(props: Any) -> Any {
+def:pub TweetCard(props: any) -> JsxElement {
     tweet = props.tweet;
     myUsername = props.myUsername;
     onLike = props.onLike;
@@ -53,21 +53,21 @@ def:pub TweetCard(props: Any) -> Any {
             <div className="lx-tweet-actions">
                 <button
                     className="lx-act-btn lx-act-comment"
-                    onClick={lambda -> None { showComments = not showComments; }}
+                    onClick={lambda { showComments = not showComments; }}
                 >
                     <MessageCircle size={16} />
                     <span>{comment_count}</span>
                 </button>
                 <button
                     className="lx-act-btn lx-act-repost"
-                    onClick={lambda -> None { repostFn.call(None, tweet["id"], tweet["content"], tweet["author_username"]); }}
+                    onClick={lambda { repostFn.call(None, tweet["id"], tweet["content"], tweet["author_username"]); }}
                     title="Repost"
                 >
                     <Repeat2 size={16} />
                 </button>
                 <button
                     className={"lx-act-btn lx-act-liked" if is_liked else "lx-act-btn lx-act-like"}
-                    onClick={lambda -> None { likeFn.call(None, tweet["id"]); }}
+                    onClick={lambda { likeFn.call(None, tweet["id"]); }}
                 >
                     <Heart size={16} />
                     <span>{like_count}</span>
@@ -75,7 +75,7 @@ def:pub TweetCard(props: Any) -> Any {
                 {(
                     <button
                         className="lx-act-btn lx-act-delete"
-                        onClick={lambda -> None { if confirm("Delete this post? This cannot be undone.") { deleteFn.call(None, tweet["id"]); } }}
+                        onClick={lambda { if confirm("Delete this post? This cannot be undone.") { deleteFn.call(None, tweet["id"]); } }}
                     >
                         <Trash2 size={16} />
                     </button>
@@ -100,8 +100,8 @@ def:pub TweetCard(props: Any) -> Any {
                             className="lx-comment-input"
                             placeholder="Reply..."
                             value={commentText}
-                            onChange={lambda e: Any -> None { commentText = e.target.value; }}
-                            onKeyDown={lambda e: Any -> None {
+                            onChange={lambda e: ChangeEvent { commentText = e.target.value; }}
+                            onKeyDown={lambda e: KeyboardEvent {
                                 if e.key == "Enter" and commentText.trim() {
                                     commentFn.call(None, tweet["id"], commentText);
                                     commentText = "";
@@ -110,7 +110,7 @@ def:pub TweetCard(props: Any) -> Any {
                         />
                         <button
                             className="lx-comment-submit"
-                            onClick={lambda -> None {
+                            onClick={lambda {
                                 if commentText.trim() {
                                     commentFn.call(None, tweet["id"], commentText);
                                     commentText = "";

--- a/littleX_FULLSTACK/frontend.cl.jac
+++ b/littleX_FULLSTACK/frontend.cl.jac
@@ -2,12 +2,13 @@
 
 import from "@jac/runtime" { jacSignup, jacLogin, jacLogout, jacIsLoggedIn }
 sv import from .server { setup_profile, get_profile, get_all_profiles, follow_user, unfollow_user, create_tweet, delete_tweet, like_tweet, add_comment, load_feed, get_trending, create_channel, join_channel, leave_channel, get_channels, get_channel_detail, create_channel_tweet }
+sv import from .server { UserView, TweetView, ChannelView, TrendingTag }
 import from "lucide-react" { Home, Compass, User, LogOut, Search, Feather, Hash, Users, Plus, ArrowLeft, X }
 import from .components.TweetCard { TweetCard }
 import from .components.AuthForm { AuthForm }
 import "./global.css";
 
-def:pub app() -> Any {
+def:pub app -> JsxElement {
     has isLoggedIn: bool = False,
         checkingAuth: bool = True,
         isSignup: bool = False,
@@ -16,21 +17,21 @@ def:pub app() -> Any {
         authError: str = "",
         authLoading: bool = False,
         activeTab: str = "feed",
-        myProfile: Any = None,
-        tweets: list = [],
+        myProfile: any = None,
+        tweets: list[TweetView] = [],
         feedLoading: bool = True,
         composerText: str = "",
         searchQuery: str = "",
-        allProfiles: list = [],
+        allProfiles: list[UserView] = [],
         editingBio: bool = False,
         bioText: str = "",
-        trendingTags: list = [],
+        trendingTags: list[TrendingTag] = [],
         notifCount: int = 0,
         showWelcome: bool = False,
-        channels: list = [],
+        channels: list[ChannelView] = [],
         channelsLoading: bool = False,
-        selectedChannel: Any = None,
-        channelPosts: list = [],
+        selectedChannel: any = None,
+        channelPosts: list[TweetView] = [],
         channelComposerText: str = "",
         showCreateChannel: bool = False,
         newChannelName: str = "",
@@ -81,10 +82,10 @@ def:pub app() -> Any {
             password={authPassword}
             error={authError}
             loading={authLoading}
-            onUsernameChange={lambda e: Any -> None { authUsername = e.target.value; }}
-            onPasswordChange={lambda e: Any -> None { authPassword = e.target.value; }}
-            onSubmit={lambda e: Any -> None { e.preventDefault(); if isSignup { handleSignup(); } else { handleLogin(); } }}
-            onToggleMode={lambda -> None { isSignup = not isSignup; authError = ""; }}
+            onUsernameChange={lambda e: ChangeEvent { authUsername = e.target.value; }}
+            onPasswordChange={lambda e: ChangeEvent { authPassword = e.target.value; }}
+            onSubmit={lambda e: FormEvent { e.preventDefault(); if isSignup { handleSignup(); } else { handleLogin(); } }}
+            onToggleMode={lambda { isSignup = not isSignup; authError = ""; }}
         />;
     }
 
@@ -99,7 +100,7 @@ def:pub app() -> Any {
     ring_progress = Math.min(1.0, (280 - charsLeft) / 280.0);
     ring_offset = String(62.83 * (1.0 - ring_progress));
     ring_color = "#ef4444" if charsLeft < 0 else ("#f97316" if charsLeft < 50 else ("#fb923c" if charsLeft < 100 else "#2a2a35"));
-    toFollow = [u for u in allProfiles if not followingIds.includes(u["id"]) and u["id"] != (myProfile.id if myProfile else "")];
+    toFollow = [u for u in allProfiles if not followingIds.includes(u.id) and u.id != (myProfile.id if myProfile else "")];
     current_total_activity = (myProfile.tweets if myProfile and myProfile.tweets else []).reduce(lambda acc, t: acc + t["likes"].length + t["comments"].length, 0);
 
     return <div className="lx-root">
@@ -112,28 +113,28 @@ def:pub app() -> Any {
             <nav className="lx-nav">
                 <div
                     className={"lx-nav-item" + (" lx-nav-item-active" if activeTab == "feed" else "")}
-                    onClick={lambda -> None { activeTab = "feed"; if searchQuery { searchQuery = ""; handleSearch(""); } }}
+                    onClick={lambda { activeTab = "feed"; if searchQuery { searchQuery = ""; handleSearch(""); } }}
                 >
                     <Home size={22} />
                     <span>Home</span>
                 </div>
                 <div
                     className={"lx-nav-item" + (" lx-nav-item-active" if activeTab == "explore" else "")}
-                    onClick={lambda -> None { activeTab = "explore"; }}
+                    onClick={lambda { activeTab = "explore"; }}
                 >
                     <Compass size={22} />
                     <span>Explore</span>
                 </div>
                 <div
                     className={"lx-nav-item" + (" lx-nav-item-active" if activeTab == "channels" else "")}
-                    onClick={lambda -> None { activeTab = "channels"; loadChannels(); }}
+                    onClick={lambda { activeTab = "channels"; loadChannels(); }}
                 >
                     <Hash size={22} />
                     <span>Channels</span>
                 </div>
                 <div
                     className={"lx-nav-item" + (" lx-nav-item-active" if activeTab == "profile" else "")}
-                    onClick={lambda -> None { activeTab = "profile"; localStorage.setItem("lx_activity_total", String(current_total_activity)); notifCount = 0; }}
+                    onClick={lambda { activeTab = "profile"; localStorage.setItem("lx_activity_total", String(current_total_activity)); notifCount = 0; }}
                 >
                     <User size={22} />
                     <span>Profile</span>
@@ -143,7 +144,7 @@ def:pub app() -> Any {
                 </div>
             </nav>
 
-            <button className="lx-compose-btn" onClick={lambda -> None { activeTab = "feed"; }}>
+            <button className="lx-compose-btn" onClick={lambda { activeTab = "feed"; }}>
                 <Feather size={18} />
                 <span>Post</span>
             </button>
@@ -156,7 +157,7 @@ def:pub app() -> Any {
                     <div className="lx-sidebar-user-name">{displayUsername}</div>
                     <div className="lx-sidebar-user-handle">{"@" + displayUsername}</div>
                 </div>
-                <button className="lx-logout-icon-btn" onClick={lambda -> None { handleLogout(); }}>
+                <button className="lx-logout-icon-btn" onClick={lambda { handleLogout(); }}>
                     <LogOut size={18} />
                 </button>
             </div>
@@ -170,7 +171,7 @@ def:pub app() -> Any {
                 {(
                     <button
                         className="lx-edit-profile-btn"
-                        onClick={lambda -> None { editingBio = not editingBio; bioText = (myProfile.bio if myProfile and myProfile.bio else ""); }}
+                        onClick={lambda { editingBio = not editingBio; bioText = (myProfile.bio if myProfile and myProfile.bio else ""); }}
                     >
                         {"Cancel" if editingBio else "Edit profile"}
                     </button>
@@ -189,7 +190,7 @@ def:pub app() -> Any {
                                     <span className="lx-welcome-tip">{"Explore and follow people in Explore"}</span>
                                 </div>
                             </div>
-                            <button className="lx-welcome-dismiss" onClick={lambda -> None { handleDismissWelcome(); }}>
+                            <button className="lx-welcome-dismiss" onClick={lambda { handleDismissWelcome(); }}>
                                 {"Got it"}
                             </button>
                         </div>
@@ -201,7 +202,7 @@ def:pub app() -> Any {
                                 className="lx-composer-textarea"
                                 placeholder="What's happening?"
                                 value={composerText}
-                                onChange={lambda e: Any -> None { composerText = e.target.value; }}
+                                onChange={lambda e: ChangeEvent { composerText = e.target.value; }}
                                 rows={3}
                             />
                             <div className="lx-composer-footer">
@@ -227,7 +228,7 @@ def:pub app() -> Any {
                                 <button
                                     className="lx-post-btn"
                                     disabled={not composerText.trim() or charsLeft < 0}
-                                    onClick={lambda -> None { postTweet(); }}
+                                    onClick={lambda { postTweet(); }}
                                 >
                                     Post
                                 </button>
@@ -246,10 +247,10 @@ def:pub app() -> Any {
                                     <div className="lx-empty-title">Nothing here yet</div>
                                     <span>Follow people or post something!</span>
                                 </div>
-                            ) if tweets.length == 0 else None}
+                            ) if len(tweets) == 0 else None}
                             {[
                                 <TweetCard
-                                    key={tweet["id"]}
+                                    key={tweet.id}
                                     tweet={tweet}
                                     myUsername={profileUsername}
                                     onLike={handleLike}
@@ -269,28 +270,28 @@ def:pub app() -> Any {
                         <div className="lx-loading">Loading users...</div>
                     ) if not allProfiles else None}
                     {[
-                        <div className="lx-explore-item" key={u["id"]}>
-                            <img className="lx-avatar" src={"https://i.pravatar.cc/150?u=fake@" + u["username"]} alt={u["username"]} />
+                        <div className="lx-explore-item" key={u.id}>
+                            <img className="lx-avatar" src={"https://i.pravatar.cc/150?u=fake@" + u.username} alt={u.username} />
                             <div className="lx-explore-info">
-                                <div className="lx-explore-name">{u["username"].split("@")[0] if u["username"].includes("@") else u["username"]}</div>
-                                <div className="lx-explore-handle">{"@" + (u["username"].split("@")[0] if u["username"].includes("@") else u["username"])}</div>
-                                <div className="lx-explore-bio">{u["bio"] if u["bio"] else "No bio yet"}</div>
+                                <div className="lx-explore-name">{u.username.split("@")[0] if "@" in u.username else u.username}</div>
+                                <div className="lx-explore-handle">{"@" + (u.username.split("@")[0] if "@" in u.username else u.username)}</div>
+                                <div className="lx-explore-bio">{u.bio if u.bio else "No bio yet"}</div>
                             </div>
                             {(
                                 <button
                                     className="lx-unfollow-btn"
-                                    onClick={lambda -> None { handleUnfollow(u["id"]); }}
+                                    onClick={lambda { handleUnfollow(u.id); }}
                                 >
                                     Following
                                 </button>
-                            ) if followingIds.includes(u["id"]) else (
+                            ) if followingIds.includes(u.id) else (
                                 <button
                                     className="lx-follow-btn"
-                                    onClick={lambda -> None { handleFollow(u["id"]); }}
+                                    onClick={lambda { handleFollow(u.id); }}
                                 >
                                     Follow
                                 </button>
-                            ) if u["id"] != (myProfile.id if myProfile else "") else None}
+                            ) if u.id != (myProfile.id if myProfile else "") else None}
                         </div>
                         for u in allProfiles
                     ]}
@@ -304,7 +305,7 @@ def:pub app() -> Any {
                             <div className="lx-channel-actions">
                                 <button
                                     className="lx-post-btn"
-                                    onClick={lambda -> None { showCreateChannel = not showCreateChannel; }}
+                                    onClick={lambda { showCreateChannel = not showCreateChannel; }}
                                 >
                                     <Plus size={16} />
                                     {"Create Channel"}
@@ -317,25 +318,25 @@ def:pub app() -> Any {
                                         className="lx-input"
                                         placeholder="Channel name"
                                         value={newChannelName}
-                                        onChange={lambda e: Any -> None { newChannelName = e.target.value; }}
+                                        onChange={lambda e: ChangeEvent { newChannelName = e.target.value; }}
                                     />
                                     <input
                                         className="lx-input"
                                         placeholder="Description (optional)"
                                         value={newChannelDescription}
-                                        onChange={lambda e: Any -> None { newChannelDescription = e.target.value; }}
+                                        onChange={lambda e: ChangeEvent { newChannelDescription = e.target.value; }}
                                     />
                                     <div style={{"display": "flex", "gap": "0.5rem"}}>
                                         <button
                                             className="lx-post-btn"
                                             disabled={not newChannelName.trim()}
-                                            onClick={lambda -> None { handleCreateChannel(); }}
+                                            onClick={lambda { handleCreateChannel(); }}
                                         >
                                             Create
                                         </button>
                                         <button
                                             className="lx-edit-profile-btn"
-                                            onClick={lambda -> None { showCreateChannel = False; newChannelName = ""; newChannelDescription = ""; }}
+                                            onClick={lambda { showCreateChannel = False; newChannelName = ""; newChannelDescription = ""; }}
                                         >
                                             Cancel
                                         </button>
@@ -354,29 +355,29 @@ def:pub app() -> Any {
                                             <div className="lx-empty-title">No channels yet</div>
                                             <span>Create one to get started!</span>
                                         </div>
-                                    ) if channels.length == 0 else None}
+                                    ) if len(channels) == 0 else None}
                                     {[
                                         <div
                                             className="lx-channel-item"
-                                            key={ch["id"]}
-                                            onClick={lambda -> None { handleSelectChannel(ch["id"]); }}
+                                            key={ch.id}
+                                            onClick={lambda { handleSelectChannel(ch.id); }}
                                         >
                                             <div className="lx-channel-icon">
                                                 <Hash size={20} />
                                             </div>
                                             <div className="lx-channel-item-info">
-                                                <div className="lx-channel-item-name">{ch["name"]}</div>
+                                                <div className="lx-channel-item-name">{ch.name}</div>
                                                 {(
-                                                    <div className="lx-channel-item-desc">{ch["description"]}</div>
-                                                ) if ch["description"] else None}
+                                                    <div className="lx-channel-item-desc">{ch.description}</div>
+                                                ) if ch.description else None}
                                                 <div className="lx-channel-item-meta">
                                                     <Users size={12} />
-                                                    <span>{String(ch["member_count"]) + (" member" if ch["member_count"] == 1 else " members")}</span>
+                                                    <span>{String(ch.member_count) + (" member" if ch.member_count == 1 else " members")}</span>
                                                 </div>
                                             </div>
                                             {(
                                                 <span className="lx-channel-joined-badge">Joined</span>
-                                            ) if ch["is_member"] else None}
+                                            ) if ch.is_member else None}
                                         </div>
                                         for ch in channels
                                     ]}
@@ -388,7 +389,7 @@ def:pub app() -> Any {
                             <div className="lx-channel-header">
                                 <button
                                     className="lx-edit-profile-btn"
-                                    onClick={lambda -> None { handleBackToChannels(); }}
+                                    onClick={lambda { handleBackToChannels(); }}
                                     style={{"display": "flex", "alignItems": "center", "gap": "0.3rem"}}
                                 >
                                     <ArrowLeft size={16} />
@@ -407,14 +408,14 @@ def:pub app() -> Any {
                                     {(
                                         <button
                                             className="lx-edit-profile-btn"
-                                            onClick={lambda -> None { handleLeaveChannel(selectedChannel.id); }}
+                                            onClick={lambda { handleLeaveChannel(selectedChannel.id); }}
                                         >
                                             Leave
                                         </button>
                                     ) if selectedChannel.is_member else (
                                         <button
                                             className="lx-follow-btn"
-                                            onClick={lambda -> None { handleJoinChannel(selectedChannel.id); }}
+                                            onClick={lambda { handleJoinChannel(selectedChannel.id); }}
                                         >
                                             Join
                                         </button>
@@ -430,7 +431,7 @@ def:pub app() -> Any {
                                             className="lx-composer-textarea"
                                             placeholder={"Post in #" + selectedChannel.name}
                                             value={channelComposerText}
-                                            onChange={lambda e: Any -> None { channelComposerText = e.target.value; }}
+                                            onChange={lambda e: ChangeEvent { channelComposerText = e.target.value; }}
                                             rows={2}
                                         />
                                         <div className="lx-composer-footer">
@@ -438,7 +439,7 @@ def:pub app() -> Any {
                                             <button
                                                 className="lx-post-btn"
                                                 disabled={not channelComposerText.trim()}
-                                                onClick={lambda -> None { handleChannelPost(); }}
+                                                onClick={lambda { handleChannelPost(); }}
                                             >
                                                 Post
                                             </button>
@@ -452,11 +453,11 @@ def:pub app() -> Any {
                                     <div className="lx-empty-title">No posts yet</div>
                                     <span>{("Be the first to post!" if selectedChannel.is_member else "Join this channel to post!")}</span>
                                 </div>
-                            ) if channelPosts.length == 0 else None}
+                            ) if len(channelPosts) == 0 else None}
 
                             {[
                                 <TweetCard
-                                    key={tweet["id"]}
+                                    key={tweet.id}
                                     tweet={tweet}
                                     myUsername={profileUsername}
                                     onLike={handleLike}
@@ -491,15 +492,15 @@ def:pub app() -> Any {
                                     rows={3}
                                     placeholder="Write your bio..."
                                     value={bioText}
-                                    onChange={lambda e: Any -> None { bioText = e.target.value; }}
+                                    onChange={lambda e: ChangeEvent { bioText = e.target.value; }}
                                 />
                                 <div style={{"display": "flex", "gap": "0.5rem"}}>
-                                    <button className="lx-bio-save-btn" onClick={lambda -> None { handleSaveBio(); }}>
+                                    <button className="lx-bio-save-btn" onClick={lambda { handleSaveBio(); }}>
                                         Save
                                     </button>
                                     <button
                                         className="lx-edit-profile-btn"
-                                        onClick={lambda -> None { editingBio = False; }}
+                                        onClick={lambda { editingBio = False; }}
                                     >
                                         Cancel
                                     </button>
@@ -547,21 +548,21 @@ def:pub app() -> Any {
                         className="lx-search-input"
                         placeholder="Search Little-X"
                         value={searchQuery}
-                        onChange={lambda e: Any -> None { searchQuery = e.target.value; }}
-                        onKeyDown={lambda e: Any -> None { if e.key == "Enter" { handleSearch(e.target.value); } }}
+                        onChange={lambda e: ChangeEvent { searchQuery = e.target.value; }}
+                        onKeyDown={lambda e: KeyboardEvent { if e.key == "Enter" { handleSearch(e.target.value); } }}
                     />
                     {(
                         <button
                             className="lx-search-clear"
                             title="Clear search"
-                            onClick={lambda -> None { searchQuery = ""; handleSearch(""); }}
+                            onClick={lambda { searchQuery = ""; handleSearch(""); }}
                         >
                             <X size={16} />
                         </button>
                     ) if searchQuery else None}
                     <button
                         className="lx-search-btn"
-                        onClick={lambda -> None { handleSearch(searchQuery); }}
+                        onClick={lambda { handleSearch(searchQuery); }}
                     >
                         Search
                     </button>
@@ -573,43 +574,43 @@ def:pub app() -> Any {
                         {[
                             <div
                                 className="lx-trend-item"
-                                key={t["tag"]}
-                                onClick={lambda -> None { searchQuery = t["tag"]; handleSearch(t["tag"]); activeTab = "feed"; }}
+                                key={t.tag}
+                                onClick={lambda { searchQuery = t.tag; handleSearch(t.tag); activeTab = "feed"; }}
                             >
-                                <span className="lx-trend-tag">{t["tag"]}</span>
-                                <span className="lx-trend-count">{String(t["count"]) + (" post" if t["count"] == 1 else " posts")}</span>
+                                <span className="lx-trend-tag">{t.tag}</span>
+                                <span className="lx-trend-count">{String(t.count) + (" post" if t.count == 1 else " posts")}</span>
                             </div>
                             for t in trendingTags
                         ]}
                     </div>
-                ) if trendingTags.length > 0 else None}
+                ) if len(trendingTags) > 0 else None}
 
                 {(
                     <div className="lx-widget">
                         <div className="lx-widget-title">Who to follow</div>
                         {[
-                            <div className="lx-follow-item" key={u["id"]}>
-                                <img className="lx-avatar-sm" src={"https://i.pravatar.cc/150?u=fake@" + u["username"]} alt={u["username"]} />
+                            <div className="lx-follow-item" key={u.id}>
+                                <img className="lx-avatar-sm" src={"https://i.pravatar.cc/150?u=fake@" + u.username} alt={u.username} />
                                 <div className="lx-follow-item-info">
-                                    <div className="lx-follow-item-name">{u["username"].split("@")[0] if u["username"].includes("@") else u["username"]}</div>
-                                    <div className="lx-follow-item-handle">{"@" + (u["username"].split("@")[0] if u["username"].includes("@") else u["username"])}</div>
+                                    <div className="lx-follow-item-name">{u.username.split("@")[0] if "@" in u.username else u.username}</div>
+                                    <div className="lx-follow-item-handle">{"@" + (u.username.split("@")[0] if "@" in u.username else u.username)}</div>
                                 </div>
                                 <button
                                     className="lx-follow-btn"
-                                    onClick={lambda -> None { handleFollow(u["id"]); }}
+                                    onClick={lambda { handleFollow(u.id); }}
                                 >
                                     Follow
                                 </button>
                             </div>
-                            for u in toFollow.slice(0, 5)
+                            for u in toFollow[:5]
                         ]}
                         {(
-                            <div className="lx-widget-show-more" onClick={lambda -> None { activeTab = "explore"; }}>
+                            <div className="lx-widget-show-more" onClick={lambda { activeTab = "explore"; }}>
                                 Show more
                             </div>
-                        ) if toFollow.length > 5 else None}
+                        ) if len(toFollow) > 5 else None}
                     </div>
-                ) if toFollow.length > 0 else None}
+                ) if len(toFollow) > 0 else None}
 
                 <div className="lx-about-widget">
                     <div className="lx-about-title">LITTLE-X</div>
@@ -626,25 +627,25 @@ def:pub app() -> Any {
         <nav className="lx-mobile-nav">
             <div
                 className={"lx-mobile-nav-item" + (" lx-mobile-nav-item-active" if activeTab == "feed" else "")}
-                onClick={lambda -> None { activeTab = "feed"; if searchQuery { searchQuery = ""; handleSearch(""); } }}
+                onClick={lambda { activeTab = "feed"; if searchQuery { searchQuery = ""; handleSearch(""); } }}
             >
                 <Home size={24} />
             </div>
             <div
                 className={"lx-mobile-nav-item" + (" lx-mobile-nav-item-active" if activeTab == "explore" else "")}
-                onClick={lambda -> None { activeTab = "explore"; }}
+                onClick={lambda { activeTab = "explore"; }}
             >
                 <Compass size={24} />
             </div>
             <div
                 className={"lx-mobile-nav-item" + (" lx-mobile-nav-item-active" if activeTab == "channels" else "")}
-                onClick={lambda -> None { activeTab = "channels"; loadChannels(); }}
+                onClick={lambda { activeTab = "channels"; loadChannels(); }}
             >
                 <Hash size={24} />
             </div>
             <div
                 className={"lx-mobile-nav-item" + (" lx-mobile-nav-item-active" if activeTab == "profile" else "")}
-                onClick={lambda -> None { activeTab = "profile"; localStorage.setItem("lx_activity_total", String(current_total_activity)); notifCount = 0; }}
+                onClick={lambda { activeTab = "profile"; localStorage.setItem("lx_activity_total", String(current_total_activity)); notifCount = 0; }}
             >
                 <User size={24} />
                 {(
@@ -653,7 +654,7 @@ def:pub app() -> Any {
             </div>
         </nav>
 
-        <button className="lx-mobile-fab" onClick={lambda -> None { activeTab = "feed"; }}>
+        <button className="lx-mobile-fab" onClick={lambda { activeTab = "feed"; }}>
             <Feather size={22} />
         </button>
     </div>;

--- a/littleX_FULLSTACK/main.jac
+++ b/littleX_FULLSTACK/main.jac
@@ -1,31 +1,31 @@
 """Little X - Entry point combining backend and frontend."""
 
+to cl:
+
+import from .frontend { app as ClientApp }
+
+def:pub app -> JsxElement {
+    return <ClientApp/>;
+}
+
+to sv:
 
 import from server {
-        setup_profile,
-        get_profile,
-        get_all_profiles,
-        follow_user,
-        unfollow_user,
-        create_tweet,
-        delete_tweet,
-        like_tweet,
-        add_comment,
-        load_feed,
-        get_trending,
-        create_channel,
-        join_channel,
-        leave_channel,
-        get_channels,
-        get_channel_detail,
-        create_channel_tweet
-    }
-
-
-cl {
-    import from .frontend { app as ClientApp }
-
-    def:pub app() -> Any {
-        return <ClientApp />;
-    }
+    setup_profile,
+    get_profile,
+    get_all_profiles,
+    follow_user,
+    unfollow_user,
+    create_tweet,
+    delete_tweet,
+    like_tweet,
+    add_comment,
+    load_feed,
+    get_trending,
+    create_channel,
+    join_channel,
+    leave_channel,
+    get_channels,
+    get_channel_detail,
+    create_channel_tweet
 }

--- a/littleX_FULLSTACK/server.jac
+++ b/littleX_FULLSTACK/server.jac
@@ -1,26 +1,12 @@
-"""Little X - Social graph backend with TF-IDF feed ranking."""
+"""Little X - Social graph backend over an object-spatial user graph."""
 
 import datetime;
-import from sklearn.feature_extraction.text { TfidfVectorizer }
-import from sklearn.metrics.pairwise { cosine_similarity }
-
-glob _vectorizer: Any = TfidfVectorizer();
-
-def _compute_sim(query: str, content: str) -> float {
-    if not query.strip() {
-        return 1.0;
-    }
-    try {
-        t = _vectorizer.fit_transform([query, content]);
-        return float(cosine_similarity(t[0:1], t[1:2])[0][0]);
-    } except Exception {
-        return 0.0;
-    }
-}
 
 def _now() -> str {
     return datetime.datetime.utcnow().isoformat() + "Z";
 }
+
+# --- Graph archetypes: the persisted social graph ---
 
 node Profile {
     has username: str = "";
@@ -32,8 +18,8 @@ node Tweet {
     has content: str = "";
     has author_username: str = "";
     has created_at: str = "";
-    has likes: list = [];
-    has comments: list = [];
+    has likes: list[str] = [];
+    has comments: list[dict[str, str]] = [];
 }
 
 node Channel {
@@ -48,16 +34,93 @@ edge Post {}
 edge Member {}
 edge ChannelPost {}
 
+# --- View models: the typed contract returned to the client ---
+
+obj UserView {
+    has id: str;
+    has username: str;
+    has bio: str = "";
+}
+
+obj TweetView {
+    has id: str;
+    has content: str;
+    has author_username: str;
+    has created_at: str;
+    has likes: list[str];
+    has comments: list[dict[str, str]];
+    has is_mine: bool = False;
+}
+
+obj ProfileView {
+    has id: str;
+    has username: str;
+    has bio: str;
+    has followers: list[UserView];
+    has following: list[UserView];
+    has tweets: list[TweetView];
+}
+
+obj ChannelView {
+    has id: str;
+    has name: str;
+    has description: str;
+    has creator_username: str;
+    has created_at: str;
+    has member_count: int;
+    has is_member: bool;
+    has posts: list[TweetView] = [];
+}
+
+obj TrendingTag {
+    has tag: str;
+    has count: int;
+}
+
+# --- View builders: turn graph nodes into view models ---
+
+def _user_view(p: Profile) -> UserView {
+    return UserView(id=jid(p), username=p.username, bio=p.bio);
+}
+
+def _tweet_view(t: Tweet, is_mine: bool) -> TweetView {
+    return TweetView(
+        id=jid(t),
+        content=t.content,
+        author_username=t.author_username,
+        created_at=t.created_at,
+        likes=t.likes,
+        comments=t.comments,
+        is_mine=is_mine
+    );
+}
+
+# Sort keys -- typed so the type checker can resolve the comparison.
+
+def _tweet_order(t: TweetView) -> str {
+    return t.created_at;
+}
+
+def _channel_order(c: ChannelView) -> str {
+    return c.created_at;
+}
+
+def _tag_order(t: TrendingTag) -> int {
+    return t.count;
+}
+
+# --- Walkers: object-spatial agents the client spawns ---
+
 walker setup_profile {
     has username: str = "";
     has bio: str = "";
 
     can run with Root entry {
-        profiles = [-->(?:Profile)];
+        profiles = [-->[?:Profile]];
         if not profiles {
-            p = here ++> Profile(username=self.username, bio=self.bio, created_at=_now());
-            grant(p[0], level=ConnectPerm);
-            report {"id": jid(p[0]), "username": p[0].username, "bio": p[0].bio, "created_at": p[0].created_at};
+            new_profile = here ++> Profile(username=self.username, bio=self.bio, created_at=_now());
+            grant(new_profile[0], level=ConnectPerm);
+            report _user_view(new_profile[0]);
         } else {
             profile = profiles[0];
             if self.username {
@@ -66,71 +129,56 @@ walker setup_profile {
             if self.bio {
                 profile.bio = self.bio;
             }
-            report {"id": jid(profile), "username": profile.username, "bio": profile.bio, "created_at": profile.created_at};
+            report _user_view(profile);
         }
     }
 }
 
 walker get_profile {
     can run with Root entry {
-        profiles = [-->(?:Profile)];
+        profiles = [-->[?:Profile]];
         if not profiles {
             report {"error": "No profile found"};
             disengage;
         }
-        p = profiles[0];
-        my_id = jid(p);
+        me = profiles[0];
+        my_id = jid(me);
 
-        followers: list = [];
-        following: list = [];
-
+        followers: list[UserView] = [];
+        following: list[UserView] = [];
         for r in allroots() {
-            other_list = [r-->(?:Profile)];
-            if other_list {
-                other = other_list[0];
+            for other in [r-->[?:Profile]] {
                 if jid(other) != my_id {
-                    follow_out = [edge other ->:Follow:-> p];
-                    if follow_out {
-                        followers.append({"id": jid(other), "username": other.username});
+                    if [edge other ->:Follow:-> me] {
+                        followers.append(_user_view(other));
                     }
-                    follow_in = [edge p ->:Follow:-> other];
-                    if follow_in {
-                        following.append({"id": jid(other), "username": other.username});
+                    if [edge me ->:Follow:-> other] {
+                        following.append(_user_view(other));
                     }
                 }
             }
         }
 
-        tweets = [
-            {
-                "id": jid(t),
-                "content": t.content,
-                "author_username": t.author_username,
-                "created_at": t.created_at,
-                "likes": t.likes,
-                "comments": t.comments
-            }
-            for t in [p-->(?:Tweet)]
-        ];
-        tweets.sort(key=lambda t: t["created_at"], reverse=True);
-        report {
-            "id": my_id,
-            "username": p.username,
-            "bio": p.bio,
-            "followers": followers,
-            "following": following,
-            "tweets": tweets
-        };
+        tweets: list[TweetView] = [_tweet_view(t, True) for t in [me-->[?:Tweet]]];
+        tweets.sort(key=_tweet_order, reverse=True);
+
+        report ProfileView(
+            id=my_id,
+            username=me.username,
+            bio=me.bio,
+            followers=followers,
+            following=following,
+            tweets=tweets
+        );
     }
 }
 
 walker:pub get_all_profiles {
     can run with Root entry {
-        results: list = [];
+        results: list[UserView] = [];
         for r in allroots() {
-            prof = [r-->(?:Profile)];
-            if prof {
-                results.append({"id": jid(prof[0]), "username": prof[0].username, "bio": prof[0].bio});
+            for prof in [r-->[?:Profile]] {
+                results.append(_user_view(prof));
             }
         }
         report results;
@@ -141,18 +189,19 @@ walker follow_user {
     has target_id: str;
 
     can run with Root entry {
-        my_profiles = [-->(?:Profile)];
+        my_profiles = [-->[?:Profile]];
         if not my_profiles {
             report {"error": "No profile"};
             disengage;
         }
         my_profile = my_profiles[0];
         for r in allroots() {
-            target_list = [r-->(?:Profile)];
-            if target_list and jid(target_list[0]) == self.target_id {
-                my_profile +>:Follow():+> target_list[0];
-                report {"success": True};
-                disengage;
+            for target in [r-->[?:Profile]] {
+                if jid(target) == self.target_id {
+                    my_profile +>:Follow():+> target;
+                    report {"success": True};
+                    disengage;
+                }
             }
         }
         report {"error": "User not found"};
@@ -163,21 +212,22 @@ walker unfollow_user {
     has target_id: str;
 
     can run with Root entry {
-        my_profiles = [-->(?:Profile)];
+        my_profiles = [-->[?:Profile]];
         if not my_profiles {
             report {"error": "No profile"};
             disengage;
         }
         my_profile = my_profiles[0];
         for r in allroots() {
-            target_list = [r-->(?:Profile)];
-            if target_list and jid(target_list[0]) == self.target_id {
-                follow_edges = [edge my_profile ->:Follow:-> target_list[0]];
-                if follow_edges {
-                    del follow_edges[0];
+            for target in [r-->[?:Profile]] {
+                if jid(target) == self.target_id {
+                    follow_edges = [edge my_profile ->:Follow:-> target];
+                    if follow_edges {
+                        del follow_edges[0];
+                    }
+                    report {"success": True};
+                    disengage;
                 }
-                report {"success": True};
-                disengage;
             }
         }
         report {"error": "User not found"};
@@ -188,22 +238,21 @@ walker create_tweet {
     has content: str;
 
     can run with Root entry {
-        profiles = [-->(?:Profile)];
+        profiles = [-->[?:Profile]];
         if not profiles {
             report {"error": "No profile"};
             disengage;
         }
         profile = profiles[0];
-        tweet = profile +>:Post():+> Tweet(
+        new_tweets = profile +>:Post():+> Tweet(
             content=self.content,
             author_username=profile.username,
             created_at=_now(),
             likes=[],
             comments=[]
         );
-        grant(tweet[0], level=WritePerm);
-        t = tweet[0];
-        report {"id": jid(t), "content": t.content, "author_username": t.author_username, "created_at": t.created_at, "likes": t.likes, "comments": t.comments};
+        grant(new_tweets[0], level=WritePerm);
+        report _tweet_view(new_tweets[0], True);
     }
 }
 
@@ -211,21 +260,21 @@ walker delete_tweet {
     has tweet_id: str;
 
     can run with Root entry {
-        profiles = [-->(?:Profile)];
+        profiles = [-->[?:Profile]];
         if not profiles {
             report {"error": "No profile"};
             disengage;
         }
         profile = profiles[0];
-        for tweet in [profile-->(?:Tweet)] {
+        for tweet in [profile-->[?:Tweet]] {
             if jid(tweet) == self.tweet_id {
                 del tweet;
                 report {"success": True};
                 disengage;
             }
         }
-        for channel in [profile-->(?:Channel)] {
-            for tweet in [channel-->(?:Tweet)] {
+        for channel in [profile-->[?:Channel]] {
+            for tweet in [channel-->[?:Tweet]] {
                 if jid(tweet) == self.tweet_id and tweet.author_username == profile.username {
                     del tweet;
                     report {"success": True};
@@ -241,37 +290,24 @@ walker like_tweet {
     has tweet_id: str;
 
     can run with Root entry {
-        my_profiles = [-->(?:Profile)];
+        my_profiles = [-->[?:Profile]];
         if not my_profiles {
             report {"error": "No profile"};
             disengage;
         }
         username = my_profiles[0].username;
         for r in allroots() {
-            prof_list = [r-->(?:Profile)];
-            if prof_list {
-                for tweet in [prof_list[0]-->(?:Tweet)] {
+            for prof in [r-->[?:Profile]] {
+                for tweet in [prof-->[?:Tweet]] {
                     if jid(tweet) == self.tweet_id {
-                        if username in tweet.likes {
-                            tweet.likes = [u for u in tweet.likes if u != username];
-                            report {"liked": False, "likes": tweet.likes};
-                        } else {
-                            tweet.likes = tweet.likes + [username];
-                            report {"liked": True, "likes": tweet.likes};
-                        }
+                        report _toggle_like(tweet, username);
                         disengage;
                     }
                 }
-                for channel in [prof_list[0]-->(?:Channel)] {
-                    for tweet in [channel-->(?:Tweet)] {
+                for channel in [prof-->[?:Channel]] {
+                    for tweet in [channel-->[?:Tweet]] {
                         if jid(tweet) == self.tweet_id {
-                            if username in tweet.likes {
-                                tweet.likes = [u for u in tweet.likes if u != username];
-                                report {"liked": False, "likes": tweet.likes};
-                            } else {
-                                tweet.likes = tweet.likes + [username];
-                                report {"liked": True, "likes": tweet.likes};
-                            }
+                            report _toggle_like(tweet, username);
                             disengage;
                         }
                     }
@@ -280,6 +316,15 @@ walker like_tweet {
         }
         report {"error": "Tweet not found"};
     }
+}
+
+def _toggle_like(tweet: Tweet, username: str) -> dict[str, object] {
+    if username in tweet.likes {
+        tweet.likes = [u for u in tweet.likes if u != username];
+        return {"liked": False, "likes": tweet.likes};
+    }
+    tweet.likes = tweet.likes + [username];
+    return {"liked": True, "likes": tweet.likes};
 }
 
 walker add_comment {
@@ -287,29 +332,24 @@ walker add_comment {
     has content: str;
 
     can run with Root entry {
-        my_profiles = [-->(?:Profile)];
+        my_profiles = [-->[?:Profile]];
         if not my_profiles {
             report {"error": "No profile"};
             disengage;
         }
         username = my_profiles[0].username;
         for r in allroots() {
-            prof_list = [r-->(?:Profile)];
-            if prof_list {
-                for tweet in [prof_list[0]-->(?:Tweet)] {
+            for prof in [r-->[?:Profile]] {
+                for tweet in [prof-->[?:Tweet]] {
                     if jid(tweet) == self.tweet_id {
-                        comment = {"username": username, "content": self.content, "created_at": _now()};
-                        tweet.comments = tweet.comments + [comment];
-                        report {"success": True, "comment": comment};
+                        report _add_comment(tweet, username, self.content);
                         disengage;
                     }
                 }
-                for channel in [prof_list[0]-->(?:Channel)] {
-                    for tweet in [channel-->(?:Tweet)] {
+                for channel in [prof-->[?:Channel]] {
+                    for tweet in [channel-->[?:Tweet]] {
                         if jid(tweet) == self.tweet_id {
-                            comment = {"username": username, "content": self.content, "created_at": _now()};
-                            tweet.comments = tweet.comments + [comment];
-                            report {"success": True, "comment": comment};
+                            report _add_comment(tweet, username, self.content);
                             disengage;
                         }
                     }
@@ -320,13 +360,18 @@ walker add_comment {
     }
 }
 
+def _add_comment(tweet: Tweet, username: str, content: str) -> dict[str, object] {
+    comment = {"username": username, "content": content, "created_at": _now()};
+    tweet.comments = tweet.comments + [comment];
+    return {"success": True, "comment": comment};
+}
+
 walker get_trending {
     can run with Root entry {
-        tag_counts: dict = {};
+        tag_counts: dict[str, int] = {};
         for r in allroots() {
-            prof = [r-->(?:Profile)];
-            if prof {
-                for tweet in [prof[0]-->(?:Tweet)] {
+            for prof in [r-->[?:Profile]] {
+                for tweet in [prof-->[?:Tweet]] {
                     for word in tweet.content.split() {
                         if word.startswith("#") and len(word) > 1 {
                             tag = word.lower().rstrip(".,!?;:");
@@ -340,8 +385,9 @@ walker get_trending {
                 }
             }
         }
-        sorted_tags = sorted(tag_counts.items(), key=lambda x: x[1], reverse=True);
-        report [{"tag": t[0], "count": t[1]} for t in sorted_tags[:8]];
+        tags: list[TrendingTag] = [TrendingTag(tag=tag, count=tag_counts[tag]) for tag in tag_counts];
+        tags.sort(key=_tag_order, reverse=True);
+        report tags[:8];
     }
 }
 
@@ -349,49 +395,29 @@ walker load_feed {
     has search_query: str = "";
 
     can run with Root entry {
-        my_profiles = [-->(?:Profile)];
-        if not my_profiles {
+        profiles = [-->[?:Profile]];
+        if not profiles {
             report [];
             disengage;
         }
-        my_profile = my_profiles[0];
-        all_tweets: list = [];
+        my_profile = profiles[0];
+        feed: list[TweetView] = [];
 
-        for tweet in [my_profile-->(?:Tweet)] {
-            all_tweets.append({
-                "id": jid(tweet),
-                "content": tweet.content,
-                "author_username": tweet.author_username,
-                "created_at": tweet.created_at,
-                "likes": tweet.likes,
-                "comments": tweet.comments,
-                "is_mine": True
-            });
+        for tweet in [my_profile-->[?:Tweet]] {
+            feed.append(_tweet_view(tweet, True));
         }
-
-        for followed in [my_profile->:Follow:->(?:Profile)] {
-            for tweet in [followed-->(?:Tweet)] {
-                all_tweets.append({
-                    "id": jid(tweet),
-                    "content": tweet.content,
-                    "author_username": tweet.author_username,
-                    "created_at": tweet.created_at,
-                    "likes": tweet.likes,
-                    "comments": tweet.comments,
-                    "is_mine": False
-                });
+        for followed in [my_profile->:Follow:->[?:Profile]] {
+            for tweet in [followed-->[?:Tweet]] {
+                feed.append(_tweet_view(tweet, False));
             }
         }
 
         if self.search_query {
             q = self.search_query.lower().strip();
-            all_tweets = [t for t in all_tweets if q in t["content"].lower()];
-            all_tweets.sort(key=lambda t: t["created_at"], reverse=True);
-        } else {
-            all_tweets.sort(key=lambda t: t["created_at"], reverse=True);
+            feed = [t for t in feed if q in t.content.lower()];
         }
-
-        report all_tweets;
+        feed.sort(key=_tweet_order, reverse=True);
+        report feed;
     }
 }
 
@@ -400,29 +426,29 @@ walker create_channel {
     has description: str = "";
 
     can run with Root entry {
-        profiles = [-->(?:Profile)];
+        profiles = [-->[?:Profile]];
         if not profiles {
             report {"error": "No profile"};
             disengage;
         }
         profile = profiles[0];
-        channel_nodes = profile +>:Member():+> Channel(
+        new_channels = profile +>:Member():+> Channel(
             name=self.name,
             description=self.description,
             creator_username=profile.username,
             created_at=_now()
         );
-        ch = channel_nodes[0];
+        ch = new_channels[0];
         grant(ch, level=ConnectPerm);
-        report {
-            "id": jid(ch),
-            "name": ch.name,
-            "description": ch.description,
-            "creator_username": ch.creator_username,
-            "created_at": ch.created_at,
-            "member_count": 1,
-            "is_member": True
-        };
+        report ChannelView(
+            id=jid(ch),
+            name=ch.name,
+            description=ch.description,
+            creator_username=ch.creator_username,
+            created_at=ch.created_at,
+            member_count=1,
+            is_member=True
+        );
     }
 }
 
@@ -430,19 +456,17 @@ walker join_channel {
     has channel_id: str;
 
     can run with Root entry {
-        profiles = [-->(?:Profile)];
+        profiles = [-->[?:Profile]];
         if not profiles {
             report {"error": "No profile"};
             disengage;
         }
         profile = profiles[0];
         for r in allroots() {
-            prof_list = [r-->(?:Profile)];
-            if prof_list {
-                for ch in [prof_list[0]-->(?:Channel)] {
+            for prof in [r-->[?:Profile]] {
+                for ch in [prof-->[?:Channel]] {
                     if jid(ch) == self.channel_id {
-                        already = [edge profile ->:Member:-> ch];
-                        if not already {
+                        if not [edge profile ->:Member:-> ch] {
                             profile +>:Member():+> ch;
                         }
                         report {"success": True};
@@ -459,13 +483,13 @@ walker leave_channel {
     has channel_id: str;
 
     can run with Root entry {
-        profiles = [-->(?:Profile)];
+        profiles = [-->[?:Profile]];
         if not profiles {
             report {"error": "No profile"};
             disengage;
         }
         profile = profiles[0];
-        for ch in [profile-->(?:Channel)] {
+        for ch in [profile-->[?:Channel]] {
             if jid(ch) == self.channel_id {
                 member_edges = [edge profile ->:Member:-> ch];
                 if member_edges {
@@ -481,46 +505,36 @@ walker leave_channel {
 
 walker get_channels {
     can run with Root entry {
-        my_profiles = [-->(?:Profile)];
-        my_profile = my_profiles[0] if my_profiles else None;
-        my_channel_ids: list = [];
-        if my_profile {
-            my_channel_ids = [jid(ch) for ch in [my_profile-->(?:Channel)]];
+        my_profiles = [-->[?:Profile]];
+        my_channel_ids: list[str] = [];
+        if my_profiles {
+            for ch in [my_profiles[0]-->[?:Channel]] {
+                my_channel_ids.append(jid(ch));
+            }
         }
 
-        seen: dict = {};
-        channels: list = [];
+        seen: dict[str, bool] = {};
+        channels: list[ChannelView] = [];
         for r in allroots() {
-            prof_list = [r-->(?:Profile)];
-            if prof_list {
-                for ch in [prof_list[0]-->(?:Channel)] {
+            for prof in [r-->[?:Profile]] {
+                for ch in [prof-->[?:Channel]] {
                     ch_id = jid(ch);
                     if ch_id not in seen {
-                        member_count = 0;
-                        for r2 in allroots() {
-                            p2 = [r2-->(?:Profile)];
-                            if p2 {
-                                edges_to_ch = [edge p2[0] ->:Member:-> ch];
-                                if edges_to_ch {
-                                    member_count += 1;
-                                }
-                            }
-                        }
                         seen[ch_id] = True;
-                        channels.append({
-                            "id": ch_id,
-                            "name": ch.name,
-                            "description": ch.description,
-                            "creator_username": ch.creator_username,
-                            "created_at": ch.created_at,
-                            "member_count": member_count,
-                            "is_member": ch_id in my_channel_ids
-                        });
+                        channels.append(ChannelView(
+                            id=ch_id,
+                            name=ch.name,
+                            description=ch.description,
+                            creator_username=ch.creator_username,
+                            created_at=ch.created_at,
+                            member_count=len([ch<-:Member:<-[?:Profile]]),
+                            is_member=ch_id in my_channel_ids
+                        ));
                     }
                 }
             }
         }
-        channels.sort(key=lambda c: c["created_at"], reverse=True);
+        channels.sort(key=_channel_order, reverse=True);
         report channels;
     }
 }
@@ -529,51 +543,32 @@ walker get_channel_detail {
     has channel_id: str;
 
     can run with Root entry {
-        my_profiles = [-->(?:Profile)];
-        my_profile = my_profiles[0] if my_profiles else None;
-        is_member = False;
+        my_profiles = [-->[?:Profile]];
+        my_username = my_profiles[0].username if my_profiles else "";
 
         for r in allroots() {
-            prof_list = [r-->(?:Profile)];
-            if prof_list {
-                for ch in [prof_list[0]-->(?:Channel)] {
+            for prof in [r-->[?:Profile]] {
+                for ch in [prof-->[?:Channel]] {
                     if jid(ch) == self.channel_id {
-                        member_count = 0;
-                        for r2 in allroots() {
-                            p2 = [r2-->(?:Profile)];
-                            if p2 {
-                                edges_to_ch = [edge p2[0] ->:Member:-> ch];
-                                if edges_to_ch {
-                                    member_count += 1;
-                                }
-                            }
+                        is_member = False;
+                        if my_profiles and [edge my_profiles[0] ->:Member:-> ch] {
+                            is_member = True;
                         }
-                        if my_profile {
-                            my_edges = [edge my_profile ->:Member:-> ch];
-                            is_member = True if my_edges else False;
-                        }
-                        posts: list = [];
-                        for tweet in [ch-->(?:Tweet)] {
-                            posts.append({
-                                "id": jid(tweet),
-                                "content": tweet.content,
-                                "author_username": tweet.author_username,
-                                "created_at": tweet.created_at,
-                                "likes": tweet.likes,
-                                "comments": tweet.comments
-                            });
-                        }
-                        posts.sort(key=lambda p: p["created_at"], reverse=True);
-                        report {
-                            "id": jid(ch),
-                            "name": ch.name,
-                            "description": ch.description,
-                            "creator_username": ch.creator_username,
-                            "created_at": ch.created_at,
-                            "member_count": member_count,
-                            "is_member": is_member,
-                            "posts": posts
-                        };
+                        posts: list[TweetView] = [
+                            _tweet_view(t, t.author_username == my_username)
+                            for t in [ch-->[?:Tweet]]
+                        ];
+                        posts.sort(key=_tweet_order, reverse=True);
+                        report ChannelView(
+                            id=jid(ch),
+                            name=ch.name,
+                            description=ch.description,
+                            creator_username=ch.creator_username,
+                            created_at=ch.created_at,
+                            member_count=len([ch<-:Member:<-[?:Profile]]),
+                            is_member=is_member,
+                            posts=posts
+                        );
                         disengage;
                     }
                 }
@@ -588,31 +583,23 @@ walker create_channel_tweet {
     has content: str;
 
     can run with Root entry {
-        profiles = [-->(?:Profile)];
+        profiles = [-->[?:Profile]];
         if not profiles {
             report {"error": "No profile"};
             disengage;
         }
         profile = profiles[0];
-        for ch in [profile-->(?:Channel)] {
+        for ch in [profile-->[?:Channel]] {
             if jid(ch) == self.channel_id {
-                tweet = ch +>:ChannelPost():+> Tweet(
+                new_tweets = ch +>:ChannelPost():+> Tweet(
                     content=self.content,
                     author_username=profile.username,
                     created_at=_now(),
                     likes=[],
                     comments=[]
                 );
-                grant(tweet[0], level=WritePerm);
-                t = tweet[0];
-                report {
-                    "id": jid(t),
-                    "content": t.content,
-                    "author_username": t.author_username,
-                    "created_at": t.created_at,
-                    "likes": t.likes,
-                    "comments": t.comments
-                };
+                grant(new_tweets[0], level=WritePerm);
+                report _tweet_view(new_tweets[0], True);
                 disengage;
             }
         }


### PR DESCRIPTION
## Summary
Refactors `server.jac` to return typed view models instead of ad-hoc dict literals, and tightens type annotations across components.

### server.jac
- Add view-model objects (`UserView`, `TweetView`, `ProfileView`, `ChannelView`, `TrendingTag`) as the typed contract returned to the client
- Add view builders (`_user_view`, `_tweet_view`) and typed sort keys so the type checker can resolve comparisons
- Extract `_toggle_like` / `_add_comment` helpers shared across walkers
- Drop the `sklearn` TF-IDF dependency and `_compute_sim` — feed search is a plain substring match
- Compute channel `member_count` via `Member` edge traversal instead of a nested `allroots()` scan
- Switch node-filter syntax from `(?:Type)` to `[?:Type]`

### components / frontend
- Annotate component returns as `JsxElement` and props as `any`

## Files
- `server.jac` — view models, view builders, helpers, member-count simplification
- `frontend.cl.jac`, `components/AuthForm.cl.jac`, `components/Button.cl.jac`, `components/TweetCard.cl.jac` — type annotations
- `main.jac` — type annotations